### PR TITLE
Fix fall-through in task executor switch

### DIFF
--- a/cli_run_model/tasks_executor/index.js
+++ b/cli_run_model/tasks_executor/index.js
@@ -29,7 +29,7 @@ if (options.file) {
 
 async function executeTasks(tasks) {
   // Mock function to execute tasks and return results
-  let evidencs = {};
+  let evidence = {};
   let runningTasks = [];
   tasks.map(async (task) => {
     switch (task.action) {
@@ -40,20 +40,22 @@ async function executeTasks(tasks) {
           task.data.range.from,
           task.data.range.to
         ));
+        break;
       case "LOOK_STOCK_PRICE":
         runningTasks.push(getStockPrice(
           task.data.symbol,
           task.data.range.from,
           task.data.range.to
-        ));   
+        ));
+        break;
       default:
-        // do nothing; 
+        // do nothing;
     }
   });
 
-  evidencs = await Promise.all(runningTasks);
+  evidence = await Promise.all(runningTasks);
 
-  return {"report":evidencs[0],"stock":evidencs[1]};
+  return {"report": evidence[0], "stock": evidence[1]};
 }
 
 async function getStockPrice(symbol, from, to) {


### PR DESCRIPTION
## Summary
- prevent fall-through in `executeTasks` switch statement
- rename evidence variable for clarity

## Testing
- `node cli_run_model/tasks_executor/index.js --file /tmp/tasks.json` *(fails: Cannot find module 'commander')*

------
https://chatgpt.com/codex/tasks/task_e_68702916ba508326acf07e8416f9cc81